### PR TITLE
Add CMakeFiles to automatically excluded dirs

### DIFF
--- a/src/DirInclusionManager.cpp
+++ b/src/DirInclusionManager.cpp
@@ -29,6 +29,7 @@ static const std::string f_builtin_dir_excludes[] =
 	".hg",
 	".metadata",
 	".svn",
+	"CMakeFiles",
 	"CVS",
 	"autom4te.cache",
 	""


### PR DESCRIPTION
CMakeFiles is automatically generated when configuring a build tree for CMake, and is a lot like autom4te.cache in that respect. Not much reason to automatically search it that I can think of.

Also, since it looked like the directories were listed in ASCIIbetical order, I added it where that order would be maintained.