### PR TITLE
Add sstream include to fix compilation with clang with libc++

### DIFF
--- a/src/FileScanner.cpp
+++ b/src/FileScanner.cpp
@@ -30,6 +30,7 @@
 #include <pcre.h>
 #endif
 #include <regex>
+#include <sstream>
 #include <thread>
 #include <mutex>
 #ifndef HAVE_SCHED_SETAFFINITY


### PR DESCRIPTION
Unlike libstdc++ , libc++ only includes the needed headers. FileScanner.cpp uses std::ostringstream but fails to include sstream header. The fix is to explicitly add sstream include.